### PR TITLE
Fix URL path to ProductImages in HTTP request

### DIFF
--- a/srv/handlers/testImage.http
+++ b/srv/handlers/testImage.http
@@ -1,2 +1,2 @@
-GET http://localhost:4004/MasterDataService/Products('HT-1000')/image HTTP/1.1
+GET http://localhost:4004/odata/v4/MasterDataService/ProductImages('HT-1000')/image HTTP/1.1
 Content-Type: application/octet-stream


### PR DESCRIPTION
Updating the URL in the HTTP get request. The new URL aligns with the fix included in the YouTube video - https://youtu.be/3Gpo36n8kqk?t=946